### PR TITLE
fix: ensure latest plan selection and lint setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+/dist
+/tmp
+/.idea
+/.vscode
+.DS_Store
+/backend/dist
+/backend/node_modules
+/backend/package-lock.json
+/frontend/dist
+/frontend/node_modules
+/frontend/package-lock.json
+database.sqlite

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
-# codex-meal-planner
-An Application to help prep meals and save on groceries
+# Smart Meal Planner & Grocery Saver
+
+An Angular + NestJS project that helps you plan balanced weekly meals, automatically build a grocery list, and discover cheaper substitutions before you shop.
+
+## Project structure
+
+```
+./backend   # NestJS API with SQLite + TypeORM
+./frontend  # Angular single-page application
+```
+
+## Getting started
+
+1. **Install dependencies** (requires Node.js 18+):
+   ```bash
+   cd backend && npm install
+   cd ../frontend && npm install
+   ```
+
+2. **Seed the database** with curated ingredients, recipes, and an initial weekly plan:
+   ```bash
+   cd backend
+   npm run seed
+   ```
+
+3. **Run the backend API**:
+   ```bash
+   cd backend
+   npm run start:dev
+   ```
+   The NestJS server listens on [http://localhost:3000](http://localhost:3000) by default.
+
+4. **Run the Angular SPA**:
+   ```bash
+   cd frontend
+   npm start
+   ```
+   The app uses a development proxy so API calls to `/meal-plans`, `/grocery-list`, etc. are forwarded to the NestJS server.
+
+## Features
+
+- Weekly meal planner that balances breakfast, lunch, and dinner across your recipe library.
+- Smart grocery list builder with automatic quantity aggregation and estimated costs.
+- Cheaper substitution suggestions per ingredient based on category pricing.
+- Interactive Angular dashboard to review the menu, tweak highlighted recipes, and regenerate plans.
+- Automatic tracking of when each plan was generated so the newest schedule is always treated as current, even if it starts in the past.
+- One-command seed script to populate the database with example data for immediate exploration.
+
+## API overview
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/meal-plans/current` | GET | Fetch the most recent meal plan |
+| `/meal-plans/:id` | GET | Fetch a meal plan by id |
+| `/meal-plans/current/summary` | GET | Plan + recipe summary to power the UI |
+| `/meal-plans/generate` | POST | Generate and persist a new 7-day plan |
+| `/grocery-list/current` | GET | Aggregated grocery list with substitution hints |
+| `/recipes` | GET | List all available recipes (with ingredients) |
+| `/ingredients` | GET | List all ingredients |
+
+> **Note:** The generator requires at least one breakfast, lunch, and dinner recipe. The seed script already provides a balanced selection.
+
+## Seeding details
+
+The seed script loads:
+
+- 20+ pantry staples with pricing, unit, and category metadata.
+- 9 balanced recipes (3 each for breakfast, lunch, and dinner) with ingredient breakdowns.
+- An automatically generated weekly plan using those recipes.
+
+You can safely re-run `npm run seed` to reset the database and regenerate a fresh plan.
+
+## Testing
+
+For now there are no automated tests configured, but the backend and frontend projects both include linting scripts:
+
+```bash
+cd backend && npm run lint
+cd frontend && npm run lint
+```
+
+Feel free to expand this workflow with Jest (Nest) and Karma/Jest (Angular) as the project evolves.

--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname,
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'prettier'
+  ],
+  env: {
+    node: true,
+    jest: false
+  },
+  ignorePatterns: ['dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+    ]
+  }
+};

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -1,0 +1,25 @@
+import eslintConfigPrettier from 'eslint-config-prettier';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+        project: ['./tsconfig.json']
+      }
+    },
+    rules: {
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+      ]
+    }
+  },
+  eslintConfigPrettier
+);

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "smart-meal-planner-backend",
+  "version": "0.0.1",
+  "description": "NestJS backend for the Smart Meal Planner & Grocery Saver",
+  "license": "MIT",
+  "scripts": {
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "build": "nest build",
+    "lint": "eslint --ext .ts src",
+    "seed": "ts-node -r tsconfig-paths/register src/seed.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-express": "^10.3.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "sqlite3": "^5.1.7",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.2",
+    "@nestjs/schematics": "^10.1.0",
+    "@nestjs/testing": "^10.3.0",
+    "@types/node": "^20.10.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.1",
+    "@typescript-eslint/parser": "^6.13.1",
+    "eslint": "^8.55.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.1.0",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/backend/src/app/app.module.ts
+++ b/backend/src/app/app.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MealPlansModule } from '../meal-plans/meal-plans.module';
+import { RecipesModule } from '../recipes/recipes.module';
+import { IngredientsModule } from '../ingredients/ingredients.module';
+import { GroceryModule } from '../grocery/grocery.module';
+import { Ingredient } from '../ingredients/ingredient.entity';
+import { Recipe } from '../recipes/recipe.entity';
+import { RecipeIngredient } from '../recipes/recipe-ingredient.entity';
+import { MealPlan } from '../meal-plans/meal-plan.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'sqlite',
+      database: process.env.DB_PATH ?? 'database.sqlite',
+      entities: [Ingredient, Recipe, RecipeIngredient, MealPlan],
+      synchronize: true
+    }),
+    IngredientsModule,
+    RecipesModule,
+    MealPlansModule,
+    GroceryModule
+  ]
+})
+export class AppModule {}

--- a/backend/src/grocery/grocery.controller.ts
+++ b/backend/src/grocery/grocery.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { GroceryService } from './grocery.service';
+import { GroceryListSummary } from './grocery.types';
+
+@Controller('grocery-list')
+export class GroceryController {
+  constructor(private readonly groceryService: GroceryService) {}
+
+  @Get('current')
+  async getCurrentList(): Promise<GroceryListSummary | null> {
+    return this.groceryService.getCurrentList();
+  }
+}

--- a/backend/src/grocery/grocery.module.ts
+++ b/backend/src/grocery/grocery.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { GroceryService } from './grocery.service';
+import { GroceryController } from './grocery.controller';
+import { MealPlansModule } from '../meal-plans/meal-plans.module';
+import { IngredientsModule } from '../ingredients/ingredients.module';
+
+@Module({
+  imports: [MealPlansModule, IngredientsModule],
+  providers: [GroceryService],
+  controllers: [GroceryController]
+})
+export class GroceryModule {}

--- a/backend/src/grocery/grocery.service.ts
+++ b/backend/src/grocery/grocery.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@nestjs/common';
+import { IngredientsService } from '../ingredients/ingredients.service';
+import { MealPlansService } from '../meal-plans/meal-plans.service';
+import { MealType } from '../recipes/recipe.entity';
+import {
+  GroceryListItem,
+  GroceryListSummary,
+  MealPlansSummary
+} from './grocery.types';
+
+@Injectable()
+export class GroceryService {
+  constructor(
+    private readonly mealPlansService: MealPlansService,
+    private readonly ingredientsService: IngredientsService
+  ) {}
+
+  async getCurrentList(): Promise<GroceryListSummary | null> {
+    const plan = await this.mealPlansService.getCurrentPlan();
+    if (!plan) {
+      return null;
+    }
+    return this.createFromSummary(await this.mealPlansService.summarizePlan(plan));
+  }
+
+  async createFromSummary(
+    summary: MealPlansSummary
+  ): Promise<GroceryListSummary> {
+    const usage = this.countRecipeUsage(summary);
+    const aggregate = new Map<number, GroceryListItem>();
+
+    summary.recipes.forEach((recipe) => {
+      const multiplier = usage.get(recipe.id) ?? 0;
+      if (multiplier === 0) {
+        return;
+      }
+      recipe.ingredients.forEach((ri) => {
+        const existing = aggregate.get(ri.ingredient.id);
+        const totalQuantity = ri.quantity * multiplier;
+        const estimatedCost = ri.ingredient.pricePerUnit * totalQuantity;
+        if (existing) {
+          existing.totalQuantity += totalQuantity;
+          existing.estimatedCost += estimatedCost;
+        } else {
+          aggregate.set(ri.ingredient.id, {
+            ingredient: ri.ingredient,
+            unit: ri.unit,
+            totalQuantity,
+            estimatedCost
+          });
+        }
+      });
+    });
+
+    const itemsWithSuggestions = await Promise.all(
+      Array.from(aggregate.values()).map(async (item) => {
+        const substitution = await this.ingredientsService.findCheaperAlternative(
+          item.ingredient
+        );
+        if (substitution) {
+          const potentialSavings =
+            item.totalQuantity *
+            (item.ingredient.pricePerUnit - substitution.pricePerUnit);
+          return {
+            ...item,
+            substitution,
+            potentialSavings: Math.max(potentialSavings, 0)
+          };
+        }
+        return item;
+      })
+    );
+
+    const totalCost = itemsWithSuggestions.reduce(
+      (sum, item) => sum + item.estimatedCost,
+      0
+    );
+    const potentialSavings = itemsWithSuggestions.reduce((sum, item) => {
+      if (item.substitution && item.potentialSavings) {
+        return sum + item.potentialSavings;
+      }
+      return sum;
+    }, 0);
+
+    return {
+      items: itemsWithSuggestions.sort((a, b) =>
+        a.ingredient.name.localeCompare(b.ingredient.name)
+      ),
+      totalCost,
+      potentialSavings
+    };
+  }
+
+  private countRecipeUsage(summary: MealPlansSummary): Map<number, number> {
+    const usage = new Map<number, number>();
+    summary.plan.days.forEach((day) => {
+      (Object.keys(day.meals) as MealType[]).forEach((type) => {
+        const meal = day.meals[type];
+        usage.set(meal.recipeId, (usage.get(meal.recipeId) ?? 0) + 1);
+      });
+    });
+    return usage;
+  }
+}

--- a/backend/src/grocery/grocery.types.ts
+++ b/backend/src/grocery/grocery.types.ts
@@ -1,0 +1,23 @@
+import { Ingredient } from '../ingredients/ingredient.entity';
+import { MealPlan } from '../meal-plans/meal-plan.entity';
+import { Recipe } from '../recipes/recipe.entity';
+
+export interface GroceryListItem {
+  ingredient: Ingredient;
+  totalQuantity: number;
+  unit: string;
+  estimatedCost: number;
+  substitution?: Ingredient | null;
+  potentialSavings?: number;
+}
+
+export interface GroceryListSummary {
+  items: GroceryListItem[];
+  totalCost: number;
+  potentialSavings: number;
+}
+
+export interface MealPlansSummary {
+  plan: MealPlan;
+  recipes: Recipe[];
+}

--- a/backend/src/ingredients/ingredient.entity.ts
+++ b/backend/src/ingredients/ingredient.entity.ts
@@ -1,0 +1,31 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { RecipeIngredient } from '../recipes/recipe-ingredient.entity';
+
+export type IngredientCategory =
+  | 'produce'
+  | 'protein'
+  | 'dairy'
+  | 'grain'
+  | 'pantry'
+  | 'spice';
+
+@Entity()
+export class Ingredient {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ unique: true })
+  name!: string;
+
+  @Column({ default: 'unit' })
+  unit!: string;
+
+  @Column('float')
+  pricePerUnit!: number;
+
+  @Column({ type: 'text', default: 'pantry' })
+  category!: IngredientCategory;
+
+  @OneToMany(() => RecipeIngredient, (ri) => ri.ingredient)
+  recipeIngredients!: RecipeIngredient[];
+}

--- a/backend/src/ingredients/ingredients.controller.ts
+++ b/backend/src/ingredients/ingredients.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { Ingredient, IngredientCategory } from './ingredient.entity';
+import { IngredientsService } from './ingredients.service';
+
+@Controller('ingredients')
+export class IngredientsController {
+  constructor(private readonly ingredientsService: IngredientsService) {}
+
+  @Get()
+  async list(
+    @Query('category') category?: IngredientCategory
+  ): Promise<Ingredient[]> {
+    if (category) {
+      return this.ingredientsService.findByCategory(category);
+    }
+    return this.ingredientsService.findAll();
+  }
+}

--- a/backend/src/ingredients/ingredients.module.ts
+++ b/backend/src/ingredients/ingredients.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Ingredient } from './ingredient.entity';
+import { IngredientsService } from './ingredients.service';
+import { IngredientsController } from './ingredients.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Ingredient])],
+  providers: [IngredientsService],
+  controllers: [IngredientsController],
+  exports: [IngredientsService]
+})
+export class IngredientsModule {}

--- a/backend/src/ingredients/ingredients.service.ts
+++ b/backend/src/ingredients/ingredients.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Ingredient, IngredientCategory } from './ingredient.entity';
+
+@Injectable()
+export class IngredientsService {
+  constructor(
+    @InjectRepository(Ingredient)
+    private readonly ingredientRepository: Repository<Ingredient>
+  ) {}
+
+  findAll(): Promise<Ingredient[]> {
+    return this.ingredientRepository.find();
+  }
+
+  findByCategory(category: IngredientCategory): Promise<Ingredient[]> {
+    return this.ingredientRepository.find({ where: { category } });
+  }
+
+  async findCheaperAlternative(
+    ingredient: Ingredient
+  ): Promise<Ingredient | null> {
+    const candidates = await this.ingredientRepository.find({
+      where: { category: ingredient.category }
+    });
+    const cheaper = candidates
+      .filter((candidate) => candidate.id !== ingredient.id)
+      .filter((candidate) => candidate.pricePerUnit < ingredient.pricePerUnit)
+      .sort((a, b) => a.pricePerUnit - b.pricePerUnit)[0];
+    return cheaper ?? null;
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,16 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app/app.module';
+import { ValidationPipe } from '@nestjs/common';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, { cors: true });
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      forbidNonWhitelisted: true
+    })
+  );
+  await app.listen(process.env.PORT ?? 3000);
+}
+bootstrap();

--- a/backend/src/meal-plans/dto/generate-meal-plan.dto.ts
+++ b/backend/src/meal-plans/dto/generate-meal-plan.dto.ts
@@ -1,0 +1,11 @@
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+
+export class GenerateMealPlanDto {
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsString({ each: true })
+  highlightedRecipes?: string[];
+}

--- a/backend/src/meal-plans/meal-plan.entity.ts
+++ b/backend/src/meal-plans/meal-plan.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+import { MealType } from '../recipes/recipe.entity';
+
+export interface PlannedMeal {
+  recipeId: number;
+  recipeName: string;
+  mealType: MealType;
+}
+
+export interface DayPlan {
+  date: string;
+  meals: Record<MealType, PlannedMeal>;
+}
+
+@Entity()
+export class MealPlan {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({ type: 'date' })
+  startDate!: string;
+
+  @Column({ type: 'date' })
+  endDate!: string;
+
+  @Column({ type: 'simple-json' })
+  days!: DayPlan[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/backend/src/meal-plans/meal-plans.controller.ts
+++ b/backend/src/meal-plans/meal-plans.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post
+} from '@nestjs/common';
+import { MealPlan } from './meal-plan.entity';
+import { MealPlansService } from './meal-plans.service';
+import { GenerateMealPlanDto } from './dto/generate-meal-plan.dto';
+import { MealPlansSummary } from '../grocery/grocery.types';
+
+@Controller('meal-plans')
+export class MealPlansController {
+  constructor(private readonly mealPlansService: MealPlansService) {}
+
+  @Get('current')
+  async getCurrentPlan(): Promise<MealPlan | null> {
+    return this.mealPlansService.getCurrentPlan();
+  }
+
+  @Get(':id')
+  async getPlanById(@Param('id', ParseIntPipe) id: number): Promise<MealPlan> {
+    return this.mealPlansService.getPlanById(id);
+  }
+
+  @Get('current/summary')
+  async getCurrentSummary(): Promise<MealPlansSummary | null> {
+    const plan = await this.mealPlansService.getCurrentPlan();
+    if (!plan) {
+      return null;
+    }
+    return this.mealPlansService.summarizePlan(plan);
+  }
+
+  @Post('generate')
+  async generate(@Body() dto: GenerateMealPlanDto): Promise<MealPlan> {
+    return this.mealPlansService.generateWeeklyPlan(dto);
+  }
+}

--- a/backend/src/meal-plans/meal-plans.module.ts
+++ b/backend/src/meal-plans/meal-plans.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MealPlansService } from './meal-plans.service';
+import { MealPlansController } from './meal-plans.controller';
+import { MealPlan } from './meal-plan.entity';
+import { RecipesModule } from '../recipes/recipes.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MealPlan]), RecipesModule],
+  providers: [MealPlansService],
+  controllers: [MealPlansController],
+  exports: [MealPlansService]
+})
+export class MealPlansModule {}

--- a/backend/src/meal-plans/meal-plans.service.ts
+++ b/backend/src/meal-plans/meal-plans.service.ts
@@ -1,0 +1,146 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MealPlansSummary } from '../grocery/grocery.types';
+import { MealPlan, DayPlan, PlannedMeal } from './meal-plan.entity';
+import { GenerateMealPlanDto } from './dto/generate-meal-plan.dto';
+import { RecipesService } from '../recipes/recipes.service';
+import { MealType, Recipe } from '../recipes/recipe.entity';
+
+@Injectable()
+export class MealPlansService {
+  constructor(
+    @InjectRepository(MealPlan)
+    private readonly mealPlanRepository: Repository<MealPlan>,
+    private readonly recipesService: RecipesService
+  ) {}
+
+  async getCurrentPlan(): Promise<MealPlan | null> {
+    const [latest] = await this.mealPlanRepository.find({
+      order: { createdAt: 'DESC', startDate: 'DESC' },
+      take: 1
+    });
+    return latest ?? null;
+  }
+
+  async getPlanById(id: number): Promise<MealPlan> {
+    const plan = await this.mealPlanRepository.findOne({ where: { id } });
+    if (!plan) {
+      throw new NotFoundException(`Meal plan ${id} was not found`);
+    }
+    return plan;
+  }
+
+  async generateWeeklyPlan(dto: GenerateMealPlanDto): Promise<MealPlan> {
+    const grouped = await this.recipesService.getAllGroupedByMealType();
+    (['breakfast', 'lunch', 'dinner'] as MealType[]).forEach((type) => {
+      if (!grouped[type] || grouped[type].length === 0) {
+        throw new NotFoundException(
+          `Unable to build a plan because there are no ${type} recipes`
+        );
+      }
+    });
+
+    const highlightSet = new Set(
+      dto.highlightedRecipes?.map((name) => name.toLowerCase()) ?? []
+    );
+
+    const reorder = (recipes: Recipe[]) =>
+      [...recipes].sort((a, b) => {
+        const aHighlighted = highlightSet.has(a.name.toLowerCase()) ? 1 : 0;
+        const bHighlighted = highlightSet.has(b.name.toLowerCase()) ? 1 : 0;
+        return bHighlighted - aHighlighted || a.name.localeCompare(b.name);
+      });
+
+    const ordered: Record<MealType, Recipe[]> = {
+      breakfast: reorder(grouped.breakfast),
+      lunch: reorder(grouped.lunch),
+      dinner: reorder(grouped.dinner)
+    };
+
+    const startDate = this.resolveStartDate(dto.startDate);
+    const days: DayPlan[] = [];
+    const counters: Record<MealType, number> = {
+      breakfast: 0,
+      lunch: 0,
+      dinner: 0
+    };
+
+    for (let i = 0; i < 7; i++) {
+      const currentDate = new Date(startDate);
+      currentDate.setDate(startDate.getDate() + i);
+      const isoDate = currentDate.toISOString().split('T')[0];
+      const dayMeals: Record<MealType, PlannedMeal> = {
+        breakfast: this.recipeToPlannedMeal(
+          ordered.breakfast[counters.breakfast % ordered.breakfast.length]
+        ),
+        lunch: this.recipeToPlannedMeal(
+          ordered.lunch[counters.lunch % ordered.lunch.length]
+        ),
+        dinner: this.recipeToPlannedMeal(
+          ordered.dinner[counters.dinner % ordered.dinner.length]
+        )
+      };
+      counters.breakfast += 1;
+      counters.lunch += 1;
+      counters.dinner += 1;
+      days.push({ date: isoDate, meals: dayMeals });
+    }
+
+    const endDate = new Date(startDate);
+    endDate.setDate(startDate.getDate() + 6);
+
+    const plan = this.mealPlanRepository.create({
+      startDate: startDate.toISOString().split('T')[0],
+      endDate: endDate.toISOString().split('T')[0],
+      days
+    });
+    return this.mealPlanRepository.save(plan);
+  }
+
+  async summarizePlan(plan: MealPlan): Promise<MealPlansSummary> {
+    const recipes = await this.recipesService.findAll();
+    const recipeMap = new Map(recipes.map((recipe) => [recipe.id, recipe]));
+
+    const uniqueRecipeIds = new Set<number>();
+    plan.days.forEach((day) => {
+      (Object.keys(day.meals) as MealType[]).forEach((type) => {
+        uniqueRecipeIds.add(day.meals[type].recipeId);
+      });
+    });
+
+    const usedRecipes = Array.from(uniqueRecipeIds)
+      .map((id) => recipeMap.get(id))
+      .filter((recipe): recipe is Recipe => Boolean(recipe));
+
+    return {
+      plan,
+      recipes: usedRecipes
+    };
+  }
+
+  private resolveStartDate(input?: string): Date {
+    if (input) {
+      const parsed = new Date(input);
+      if (!isNaN(parsed.getTime())) {
+        parsed.setHours(0, 0, 0, 0);
+        return parsed;
+      }
+    }
+    const today = new Date();
+    const start = new Date(today);
+    const day = start.getDay();
+    const distanceToMonday = (8 - day) % 7; // 0 if Monday
+    start.setDate(start.getDate() + distanceToMonday);
+    start.setHours(0, 0, 0, 0);
+    return start;
+  }
+
+  private recipeToPlannedMeal(recipe: Recipe): PlannedMeal {
+    return {
+      recipeId: recipe.id,
+      recipeName: recipe.name,
+      mealType: recipe.mealType
+    };
+  }
+}

--- a/backend/src/recipes/recipe-ingredient.entity.ts
+++ b/backend/src/recipes/recipe-ingredient.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn
+} from 'typeorm';
+import { Ingredient } from '../ingredients/ingredient.entity';
+import { Recipe } from './recipe.entity';
+
+@Entity()
+export class RecipeIngredient {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => Recipe, (recipe) => recipe.ingredients, {
+    onDelete: 'CASCADE'
+  })
+  recipe!: Recipe;
+
+  @ManyToOne(() => Ingredient, (ingredient) => ingredient.recipeIngredients, {
+    eager: true,
+    onDelete: 'CASCADE'
+  })
+  ingredient!: Ingredient;
+
+  @Column('float')
+  quantity!: number;
+
+  @Column({ default: 'unit' })
+  unit!: string;
+}

--- a/backend/src/recipes/recipe.entity.ts
+++ b/backend/src/recipes/recipe.entity.ts
@@ -1,0 +1,31 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { RecipeIngredient } from './recipe-ingredient.entity';
+
+export type MealType = 'breakfast' | 'lunch' | 'dinner';
+
+@Entity()
+export class Recipe {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  name!: string;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string | null;
+
+  @Column({ type: 'text', default: 'lunch' })
+  mealType!: MealType;
+
+  @Column({ type: 'int', default: 30 })
+  prepTimeMinutes!: number;
+
+  @Column({ type: 'float', default: 1 })
+  servings!: number;
+
+  @OneToMany(() => RecipeIngredient, (ri) => ri.recipe, {
+    cascade: true,
+    eager: true
+  })
+  ingredients!: RecipeIngredient[];
+}

--- a/backend/src/recipes/recipes.controller.ts
+++ b/backend/src/recipes/recipes.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { MealType, Recipe } from './recipe.entity';
+import { RecipesService } from './recipes.service';
+
+@Controller('recipes')
+export class RecipesController {
+  constructor(private readonly recipesService: RecipesService) {}
+
+  @Get()
+  async list(@Query('mealType') mealType?: MealType): Promise<Recipe[]> {
+    if (mealType) {
+      return this.recipesService.findByMealType(mealType);
+    }
+    return this.recipesService.findAll();
+  }
+}

--- a/backend/src/recipes/recipes.module.ts
+++ b/backend/src/recipes/recipes.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Recipe } from './recipe.entity';
+import { RecipesService } from './recipes.service';
+import { RecipesController } from './recipes.controller';
+import { RecipeIngredient } from './recipe-ingredient.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Recipe, RecipeIngredient])],
+  providers: [RecipesService],
+  controllers: [RecipesController],
+  exports: [RecipesService]
+})
+export class RecipesModule {}

--- a/backend/src/recipes/recipes.service.ts
+++ b/backend/src/recipes/recipes.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Recipe, MealType } from './recipe.entity';
+
+@Injectable()
+export class RecipesService {
+  constructor(
+    @InjectRepository(Recipe)
+    private readonly recipesRepository: Repository<Recipe>
+  ) {}
+
+  findAll(): Promise<Recipe[]> {
+    return this.recipesRepository.find({ order: { name: 'ASC' } });
+  }
+
+  findByMealType(type: MealType): Promise<Recipe[]> {
+    return this.recipesRepository.find({ where: { mealType: type } });
+  }
+
+  async getAllGroupedByMealType(): Promise<Record<MealType, Recipe[]>> {
+    const recipes = await this.findAll();
+    return recipes.reduce(
+      (acc, recipe) => {
+        acc[recipe.mealType].push(recipe);
+        return acc;
+      },
+      { breakfast: [], lunch: [], dinner: [] } as Record<MealType, Recipe[]>
+    );
+  }
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -1,0 +1,207 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { Ingredient } from './ingredients/ingredient.entity';
+import { Recipe } from './recipes/recipe.entity';
+import { RecipeIngredient } from './recipes/recipe-ingredient.entity';
+import { MealPlan } from './meal-plans/meal-plan.entity';
+import { MealPlansService } from './meal-plans/meal-plans.service';
+import { RecipesService } from './recipes/recipes.service';
+
+const dataSource = new DataSource({
+  type: 'sqlite',
+  database: process.env.DB_PATH ?? 'database.sqlite',
+  entities: [Ingredient, Recipe, RecipeIngredient, MealPlan],
+  synchronize: true
+});
+
+async function seed() {
+  await dataSource.initialize();
+
+  const ingredientRepo = dataSource.getRepository(Ingredient);
+  const recipeRepo = dataSource.getRepository(Recipe);
+  const mealPlanRepo = dataSource.getRepository(MealPlan);
+
+  await mealPlanRepo.delete({});
+  await recipeRepo.delete({});
+  await ingredientRepo.delete({});
+
+  const ingredientsData = [
+    { name: 'Eggs', unit: 'dozen', pricePerUnit: 3.5, category: 'protein' },
+    { name: 'Spinach', unit: 'bunch', pricePerUnit: 1.5, category: 'produce' },
+    { name: 'Whole Wheat Bread', unit: 'loaf', pricePerUnit: 2.2, category: 'grain' },
+    { name: 'Chicken Breast', unit: 'lb', pricePerUnit: 4.5, category: 'protein' },
+    { name: 'Brown Rice', unit: 'lb', pricePerUnit: 1.8, category: 'grain' },
+    { name: 'Black Beans', unit: 'can', pricePerUnit: 1, category: 'pantry' },
+    { name: 'Greek Yogurt', unit: 'tub', pricePerUnit: 4, category: 'dairy' },
+    { name: 'Berries Mix', unit: 'lb', pricePerUnit: 3, category: 'produce' },
+    { name: 'Oats', unit: 'lb', pricePerUnit: 2, category: 'grain' },
+    { name: 'Banana', unit: 'lb', pricePerUnit: 0.6, category: 'produce' },
+    { name: 'Sweet Potato', unit: 'lb', pricePerUnit: 1.2, category: 'produce' },
+    { name: 'Chickpeas', unit: 'can', pricePerUnit: 1.1, category: 'pantry' },
+    { name: 'Tomato', unit: 'lb', pricePerUnit: 1.4, category: 'produce' },
+    { name: 'Bell Pepper', unit: 'lb', pricePerUnit: 1.5, category: 'produce' },
+    { name: 'Cheddar Cheese', unit: 'lb', pricePerUnit: 4.8, category: 'dairy' },
+    { name: 'Tofu', unit: 'lb', pricePerUnit: 2.5, category: 'protein' },
+    { name: 'Lentils', unit: 'lb', pricePerUnit: 1.3, category: 'pantry' },
+    { name: 'Quinoa', unit: 'lb', pricePerUnit: 3.2, category: 'grain' },
+    { name: 'Cucumber', unit: 'lb', pricePerUnit: 1, category: 'produce' },
+    { name: 'Olive Oil', unit: 'bottle', pricePerUnit: 6.5, category: 'pantry' },
+    { name: 'Garlic', unit: 'head', pricePerUnit: 0.5, category: 'spice' },
+    { name: 'Onion', unit: 'lb', pricePerUnit: 0.8, category: 'produce' }
+  ];
+
+  const ingredientEntities = await ingredientRepo.save(
+    ingredientsData.map((data) => ingredientRepo.create(data))
+  );
+
+  const findIngredient = (name: string) => {
+    const ingredient = ingredientEntities.find((item) => item.name === name);
+    if (!ingredient) {
+      throw new Error(`Missing ingredient ${name}`);
+    }
+    return ingredient;
+  };
+
+  const recipesData = [
+    {
+      name: 'Veggie Omelette',
+      description: 'Fluffy eggs with fresh veggies and cheese.',
+      mealType: 'breakfast',
+      prepTimeMinutes: 15,
+      servings: 2,
+      ingredients: [
+        { ingredient: findIngredient('Eggs'), quantity: 0.5, unit: 'dozen' },
+        { ingredient: findIngredient('Spinach'), quantity: 0.5, unit: 'bunch' },
+        { ingredient: findIngredient('Tomato'), quantity: 0.3, unit: 'lb' },
+        { ingredient: findIngredient('Bell Pepper'), quantity: 0.3, unit: 'lb' },
+        { ingredient: findIngredient('Cheddar Cheese'), quantity: 0.2, unit: 'lb' }
+      ]
+    },
+    {
+      name: 'Berry Yogurt Parfait',
+      description: 'Layered Greek yogurt with berries and oats.',
+      mealType: 'breakfast',
+      prepTimeMinutes: 10,
+      servings: 2,
+      ingredients: [
+        { ingredient: findIngredient('Greek Yogurt'), quantity: 0.5, unit: 'tub' },
+        { ingredient: findIngredient('Berries Mix'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Oats'), quantity: 0.2, unit: 'lb' }
+      ]
+    },
+    {
+      name: 'Banana Oatmeal',
+      description: 'Creamy oats topped with bananas and yogurt.',
+      mealType: 'breakfast',
+      prepTimeMinutes: 12,
+      servings: 2,
+      ingredients: [
+        { ingredient: findIngredient('Oats'), quantity: 0.3, unit: 'lb' },
+        { ingredient: findIngredient('Banana'), quantity: 0.5, unit: 'lb' },
+        { ingredient: findIngredient('Greek Yogurt'), quantity: 0.2, unit: 'tub' }
+      ]
+    },
+    {
+      name: 'Grilled Chicken Salad',
+      description: 'Lean grilled chicken served over hearty greens.',
+      mealType: 'lunch',
+      prepTimeMinutes: 25,
+      servings: 2,
+      ingredients: [
+        { ingredient: findIngredient('Chicken Breast'), quantity: 1, unit: 'lb' },
+        { ingredient: findIngredient('Spinach'), quantity: 0.5, unit: 'bunch' },
+        { ingredient: findIngredient('Tomato'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Cucumber'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Olive Oil'), quantity: 0.05, unit: 'bottle' }
+      ]
+    },
+    {
+      name: 'Chickpea Quinoa Bowl',
+      description: 'Protein-packed bowl with roasted veggies.',
+      mealType: 'lunch',
+      prepTimeMinutes: 30,
+      servings: 2,
+      ingredients: [
+        { ingredient: findIngredient('Quinoa'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Chickpeas'), quantity: 1, unit: 'can' },
+        { ingredient: findIngredient('Bell Pepper'), quantity: 0.3, unit: 'lb' },
+        { ingredient: findIngredient('Onion'), quantity: 0.3, unit: 'lb' },
+        { ingredient: findIngredient('Olive Oil'), quantity: 0.05, unit: 'bottle' }
+      ]
+    },
+    {
+      name: 'Lentil Soup',
+      description: 'Comforting soup simmered with aromatics.',
+      mealType: 'lunch',
+      prepTimeMinutes: 35,
+      servings: 4,
+      ingredients: [
+        { ingredient: findIngredient('Lentils'), quantity: 0.5, unit: 'lb' },
+        { ingredient: findIngredient('Tomato'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Onion'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Garlic'), quantity: 0.2, unit: 'head' }
+      ]
+    },
+    {
+      name: 'Chicken Sweet Potato Skillet',
+      description: 'One-pan chicken with caramelized sweet potatoes.',
+      mealType: 'dinner',
+      prepTimeMinutes: 30,
+      servings: 3,
+      ingredients: [
+        { ingredient: findIngredient('Chicken Breast'), quantity: 1, unit: 'lb' },
+        { ingredient: findIngredient('Sweet Potato'), quantity: 1.2, unit: 'lb' },
+        { ingredient: findIngredient('Onion'), quantity: 0.3, unit: 'lb' },
+        { ingredient: findIngredient('Garlic'), quantity: 0.1, unit: 'head' }
+      ]
+    },
+    {
+      name: 'Tofu Stir Fry',
+      description: 'Crispy tofu tossed with veggies in a light sauce.',
+      mealType: 'dinner',
+      prepTimeMinutes: 25,
+      servings: 2,
+      ingredients: [
+        { ingredient: findIngredient('Tofu'), quantity: 1, unit: 'lb' },
+        { ingredient: findIngredient('Bell Pepper'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Cucumber'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Garlic'), quantity: 0.1, unit: 'head' },
+        { ingredient: findIngredient('Olive Oil'), quantity: 0.05, unit: 'bottle' }
+      ]
+    },
+    {
+      name: 'Black Bean Rice Bowl',
+      description: 'Smoky black beans over fluffy brown rice.',
+      mealType: 'dinner',
+      prepTimeMinutes: 28,
+      servings: 3,
+      ingredients: [
+        { ingredient: findIngredient('Black Beans'), quantity: 1, unit: 'can' },
+        { ingredient: findIngredient('Brown Rice'), quantity: 0.5, unit: 'lb' },
+        { ingredient: findIngredient('Tomato'), quantity: 0.4, unit: 'lb' },
+        { ingredient: findIngredient('Onion'), quantity: 0.3, unit: 'lb' },
+        { ingredient: findIngredient('Bell Pepper'), quantity: 0.4, unit: 'lb' }
+      ]
+    }
+  ];
+
+  for (const recipeData of recipesData) {
+    const recipe = recipeRepo.create(recipeData);
+    await recipeRepo.save(recipe);
+  }
+
+  const mealPlansService = new MealPlansService(
+    mealPlanRepo as any,
+    new RecipesService(recipeRepo as any)
+  );
+
+  await mealPlansService.generateWeeklyPlan({});
+
+  console.log('Database seeded with starter data.');
+  await dataSource.destroy();
+}
+
+seed().catch((error) => {
+  console.error('Failed to seed database', error);
+  process.exit(1);
+});

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/backend/tsconfig.seed.json
+++ b/backend/tsconfig.seed.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-seed"
+  },
+  "include": ["src/**/*.ts", "src/seed.ts"]
+}

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -1,0 +1,27 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    tsconfigRootDir: __dirname,
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-type-checked'
+  ],
+  env: {
+    browser: true,
+    es2021: true
+  },
+  ignorePatterns: ['dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+    ]
+  }
+};

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "smart-meal-planner": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/smart-meal-planner",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2MB",
+                  "maximumError": "5MB"
+                }
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "outputHashing": "all"
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "smart-meal-planner:build",
+            "proxyConfig": "proxy.conf.json"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "smart-meal-planner:build:production"
+            }
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "smart-meal-planner"
+}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,23 @@
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+        project: ['./tsconfig.json']
+      }
+    },
+    rules: {
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+      ]
+    }
+  }
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "smart-meal-planner-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Angular SPA for the Smart Meal Planner & Grocery Saver",
+  "scripts": {
+    "start": "ng serve --open",
+    "build": "ng build",
+    "lint": "eslint ./src/**/*.ts"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.0.0",
+    "@angular/common": "^17.0.0",
+    "@angular/compiler": "^17.0.0",
+    "@angular/core": "^17.0.0",
+    "@angular/forms": "^17.0.0",
+    "@angular/platform-browser": "^17.0.0",
+    "@angular/platform-browser-dynamic": "^17.0.0",
+    "@angular/router": "^17.0.0",
+    "rxjs": "^7.8.1",
+    "tslib": "^2.6.0",
+    "zone.js": "^0.14.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.0.0",
+    "@angular/cli": "^17.0.0",
+    "@angular/compiler-cli": "^17.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.13.1",
+    "@typescript-eslint/parser": "^6.13.1",
+    "@types/jasmine": "~5.1.0",
+    "@types/node": "^20.10.0",
+    "eslint": "^8.55.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,10 @@
+{
+  "/api": {
+    "target": "http://localhost:3000",
+    "secure": false,
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api": ""
+    }
+  }
+}

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,0 +1,36 @@
+.app-header {
+  background: linear-gradient(135deg, #0f172a, #334155);
+  color: #f8fafc;
+  padding: 3rem 1.5rem 2rem;
+  text-align: center;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.3);
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem 0;
+  font-size: clamp(1.8rem, 2.8vw, 3rem);
+}
+
+.app-header p {
+  margin: 0;
+  font-size: 1.05rem;
+  opacity: 0.85;
+}
+
+.app-content {
+  max-width: 1100px;
+  margin: -2rem auto 0;
+  padding: 0 1.5rem 3rem;
+}
+
+.app-footer {
+  text-align: center;
+  padding: 2rem 0 3rem;
+  color: #475569;
+}
+
+.app-footer code {
+  background-color: #e2e8f0;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,15 @@
+<header class="app-header">
+  <div class="branding">
+    <h1>{{ title }}</h1>
+    <p>Plan smarter meals, save time shopping, and lower your weekly spend.</p>
+  </div>
+</header>
+<main class="app-content">
+  <app-meal-planner></app-meal-planner>
+</main>
+<footer class="app-footer">
+  <small>
+    Built with Angular & NestJS. Seed the API with <code>npm run seed</code> in the backend
+    workspace to get started quickly.
+  </small>
+</footer>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+  title = 'Smart Meal Planner & Grocery Saver';
+}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { HttpClientModule } from '@angular/common/http';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { AppComponent } from './app.component';
+import { MealPlannerComponent } from './components/meal-planner/meal-planner.component';
+
+@NgModule({
+  declarations: [AppComponent, MealPlannerComponent],
+  imports: [BrowserModule, HttpClientModule, FormsModule, ReactiveFormsModule],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}

--- a/frontend/src/app/components/meal-planner/meal-planner.component.css
+++ b/frontend/src/app/components/meal-planner/meal-planner.component.css
@@ -1,0 +1,356 @@
+.planner {
+  display: grid;
+  gap: 2rem;
+}
+
+.planner-panel {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.planner-panel h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.planner-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.planner-form label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  color: #1e293b;
+  gap: 0.35rem;
+}
+
+.planner-form input[type='date'] {
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.planner-form input[type='date']:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
+  outline: none;
+}
+
+.highlight-selector {
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1.5rem;
+  background: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.selector-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.selector-header small {
+  color: #64748b;
+}
+
+.highlight-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.highlight-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.highlight-column ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.highlight-option {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.highlight-option:hover {
+  border-color: #94a3b8;
+  box-shadow: 0 10px 25px rgba(148, 163, 184, 0.2);
+}
+
+.highlight-option input[type='checkbox'] {
+  margin-top: 0.25rem;
+}
+
+.highlight-option span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.highlight-option small {
+  color: #64748b;
+  font-weight: 500;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 2.4rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-start;
+  box-shadow: 0 20px 35px rgba(99, 102, 241, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 42px rgba(99, 102, 241, 0.35);
+}
+
+.primary-btn:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.helper-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.planner-results {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.plan-overview {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.plan-overview header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.plan-dates {
+  display: flex;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.plan-generated {
+  margin: 0;
+  flex-basis: 100%;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.days-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.day-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  padding: 1.25rem;
+  background: linear-gradient(180deg, #ffffff, #f8fafc);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.day-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #1e293b;
+}
+
+.day-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.day-card li {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.meal-type {
+  min-width: 80px;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: #64748b;
+}
+
+.meal-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.meal-details strong {
+  font-size: 1rem;
+}
+
+.meal-details small {
+  color: #64748b;
+}
+
+.grocery-section {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+}
+
+.grocery-section header h2 {
+  margin: 0 0 0.5rem 0;
+}
+
+.grocery-section header p {
+  margin: 0;
+  color: #475569;
+}
+
+.grocery-table {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.grocery-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: #f8fafc;
+}
+
+.grocery-header {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: #64748b;
+  background: transparent;
+  padding-bottom: 0;
+}
+
+.category {
+  display: inline-block;
+  margin-top: 0.15rem;
+  background: #e2e8f0;
+  color: #475569;
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.7rem;
+}
+
+.swap-suggestion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: #0f766e;
+}
+
+.swap-suggestion small {
+  font-size: 0.8rem;
+}
+
+.no-swap {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.state {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 2rem;
+  text-align: center;
+  margin-top: 1.5rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.state--loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.state--error {
+  color: #b91c1c;
+  background: #fee2e2;
+  box-shadow: none;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 4px solid #cbd5f5;
+  border-top-color: #6366f1;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (min-width: 1024px) {
+  .planner {
+    grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+    align-items: start;
+  }
+}

--- a/frontend/src/app/components/meal-planner/meal-planner.component.html
+++ b/frontend/src/app/components/meal-planner/meal-planner.component.html
@@ -1,0 +1,138 @@
+<section class="planner" *ngIf="!loading; else loadingState">
+  <div class="planner-panel">
+    <h2>Create a fresh weekly plan</h2>
+    <form (ngSubmit)="generatePlan()" class="planner-form">
+      <label>
+        <span>Start week on</span>
+        <input type="date" [formControl]="plannerForm.controls.startDate" />
+      </label>
+      <div class="highlight-selector">
+        <div class="selector-header">
+          <span>Prioritise recipes ({{ highlightCount }})</span>
+          <small>Select favourites to encourage the planner to schedule them sooner.</small>
+        </div>
+        <div class="highlight-grid">
+          <ng-container *ngFor="let type of mealTypes">
+            <div class="highlight-column">
+              <h4 class="type-heading">{{ type | titlecase }}</h4>
+              <ul>
+                <li *ngFor="let recipe of recipesByType(type)">
+                  <label class="highlight-option">
+                    <input
+                      type="checkbox"
+                      [checked]="isRecipeHighlighted(recipe)"
+                      (change)="toggleHighlight(recipe)"
+                    />
+                    <span>
+                      {{ recipe.name }}
+                      <small>
+                        {{ recipe.prepTimeMinutes }} min · Serves {{ recipe.servings }}
+                      </small>
+                    </span>
+                  </label>
+                </li>
+              </ul>
+            </div>
+          </ng-container>
+        </div>
+      </div>
+      <button type="submit" [disabled]="generating" class="primary-btn">
+        {{ generating ? 'Planning…' : 'Generate weekly plan' }}
+      </button>
+      <p class="helper-text">
+        Tip: run <code>npm run seed</code> in the backend project to pre-load recipes and
+        ingredients.
+      </p>
+    </form>
+  </div>
+
+  <div class="planner-results" *ngIf="hasPlan; else emptyState">
+    <section class="plan-overview">
+      <header>
+        <h2>Weekly menu</h2>
+        <div class="plan-dates">
+          <span>{{ plan?.startDate | date: 'longDate' }}</span>
+          <span>→</span>
+          <span>{{ plan?.endDate | date: 'longDate' }}</span>
+        </div>
+        <p class="plan-generated" *ngIf="planGeneratedAt">
+          Generated {{ planGeneratedAt }}
+        </p>
+      </header>
+      <div class="days-grid">
+        <article class="day-card" *ngFor="let day of sortedDays; trackBy: trackByDate">
+          <h3>{{ formatDate(day.date) }}</h3>
+          <ul>
+            <li *ngFor="let type of mealTypes">
+              <div class="meal-type">{{ type | titlecase }}</div>
+              <div class="meal-details">
+                <strong>{{ day.meals[type]?.recipeName }}</strong>
+                <small *ngIf="recipeForMeal(day, type) as recipe">
+                  {{ recipe.prepTimeMinutes }} min · Serves {{ recipe.servings }}
+                </small>
+              </div>
+            </li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="grocery-section" *ngIf="groceryList">
+      <header>
+        <h2>Smart grocery list</h2>
+        <p>
+          Estimated spend: <strong>{{ groceryList.totalCost | currency }}</strong>
+          <span *ngIf="groceryList.potentialSavings > 0">
+            · Potential savings up to
+            <strong>{{ groceryList.potentialSavings | currency }}</strong> with suggested swaps
+          </span>
+        </p>
+      </header>
+      <div class="grocery-table">
+        <div class="grocery-row grocery-header">
+          <span>Ingredient</span>
+          <span>Quantity</span>
+          <span>Estimated cost</span>
+          <span>Cheaper swap</span>
+        </div>
+        <div class="grocery-row" *ngFor="let item of groceryList.items">
+          <span>
+            <strong>{{ item.ingredient.name }}</strong>
+            <small class="category">{{ item.ingredient.category | titlecase }}</small>
+          </span>
+          <span>{{ item.totalQuantity | number: '1.0-2' }} {{ item.unit }}</span>
+          <span>{{ item.estimatedCost | currency }}</span>
+          <span *ngIf="item.substitution; else noSwap">
+            <div class="swap-suggestion">
+              <strong>{{ item.substitution?.name }}</strong>
+              <small>
+                Save approx. {{ item.potentialSavings || 0 | currency }} ({{
+                  item.substitution?.pricePerUnit | currency
+                }}/{{ item.substitution?.unit }})
+              </small>
+            </div>
+          </span>
+          <ng-template #noSwap>
+            <span class="no-swap">Best price found</span>
+          </ng-template>
+        </div>
+      </div>
+    </section>
+  </div>
+</section>
+
+<ng-template #loadingState>
+  <div class="state state--loading">
+    <div class="spinner" aria-hidden="true"></div>
+    <p>Loading your saved meal plan…</p>
+  </div>
+</ng-template>
+
+<ng-template #emptyState>
+  <div class="state state--empty">
+    <h2>No plan yet</h2>
+    <p>Use the planner form to generate your first schedule and shopping list.</p>
+  </div>
+</ng-template>
+
+<p class="state state--error" *ngIf="errorMessage">{{ errorMessage }}</p>

--- a/frontend/src/app/components/meal-planner/meal-planner.component.ts
+++ b/frontend/src/app/components/meal-planner/meal-planner.component.ts
@@ -1,0 +1,178 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
+import { forkJoin } from 'rxjs';
+import { ApiService } from '../../services/api.service';
+import {
+  DayPlan,
+  GenerateMealPlanRequest,
+  GroceryListSummary,
+  MealPlan,
+  MealPlanSummary,
+  MealType,
+  Recipe
+} from '../../types';
+
+@Component({
+  selector: 'app-meal-planner',
+  templateUrl: './meal-planner.component.html',
+  styleUrls: ['./meal-planner.component.css']
+})
+export class MealPlannerComponent implements OnInit {
+  loading = false;
+  generating = false;
+  errorMessage = '';
+
+  plan: MealPlan | null = null;
+  summary: MealPlanSummary | null = null;
+  groceryList: GroceryListSummary | null = null;
+  recipes: Recipe[] = [];
+
+  readonly mealTypes: MealType[] = ['breakfast', 'lunch', 'dinner'];
+  readonly plannerForm = this.fb.nonNullable.group({
+    startDate: ['']
+  });
+
+  highlightedRecipeNames = new Set<string>();
+
+  constructor(private readonly api: ApiService, private readonly fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.loadInitialData();
+  }
+
+  get hasPlan(): boolean {
+    return Boolean(this.plan?.days?.length);
+  }
+
+  get sortedDays(): DayPlan[] {
+    if (!this.plan) {
+      return [];
+    }
+    return [...this.plan.days].sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  get planGeneratedAt(): string | null {
+    const createdAt = this.plan?.createdAt;
+    if (!createdAt) {
+      return null;
+    }
+    return this.formatDateTime(createdAt);
+  }
+
+  get highlightCount(): number {
+    return this.highlightedRecipeNames.size;
+  }
+
+  recipesByType(type: MealType): Recipe[] {
+    return this.recipes.filter((recipe) => recipe.mealType === type);
+  }
+
+  isRecipeHighlighted(recipe: Recipe): boolean {
+    return this.highlightedRecipeNames.has(recipe.name);
+  }
+
+  toggleHighlight(recipe: Recipe): void {
+    if (this.highlightedRecipeNames.has(recipe.name)) {
+      this.highlightedRecipeNames.delete(recipe.name);
+    } else {
+      this.highlightedRecipeNames.add(recipe.name);
+    }
+  }
+
+  generatePlan(): void {
+    this.generating = true;
+    this.errorMessage = '';
+    const payload: GenerateMealPlanRequest = {};
+    const startDate = this.plannerForm.value.startDate?.trim();
+    if (startDate) {
+      payload.startDate = startDate;
+    }
+    if (this.highlightedRecipeNames.size > 0) {
+      payload.highlightedRecipes = Array.from(this.highlightedRecipeNames.values());
+    }
+
+    this.api.generateMealPlan(payload).subscribe({
+      next: (plan) => {
+        this.plan = plan;
+        this.refreshSummaryAndGroceries();
+        this.generating = false;
+      },
+      error: () => {
+        this.errorMessage =
+          'We could not generate a new meal plan. Please ensure the backend is running and seeded.';
+        this.generating = false;
+      }
+    });
+  }
+
+  private loadInitialData(): void {
+    this.loading = true;
+    forkJoin({
+      summary: this.api.getMealPlanSummary(),
+      grocery: this.api.getGroceryList(),
+      recipes: this.api.getRecipes()
+    }).subscribe({
+      next: ({ summary, grocery, recipes }) => {
+        this.summary = summary;
+        this.plan = summary?.plan ?? null;
+        this.groceryList = grocery;
+        this.recipes = [...recipes].sort((a, b) => a.name.localeCompare(b.name));
+        this.loading = false;
+      },
+      error: () => {
+        this.errorMessage =
+          'Unable to load data. Make sure the NestJS API is running on port 3000.';
+        this.loading = false;
+      }
+    });
+  }
+
+  private refreshSummaryAndGroceries(): void {
+    forkJoin({
+      summary: this.api.getMealPlanSummary(),
+      grocery: this.api.getGroceryList()
+    }).subscribe({
+      next: ({ summary, grocery }) => {
+        this.summary = summary;
+        this.plan = summary?.plan ?? this.plan;
+        this.groceryList = grocery;
+      },
+      error: () => {
+        this.errorMessage =
+          'The plan was generated but we could not refresh the summaries. Try reloading the page.';
+      }
+    });
+  }
+
+  formatDate(date: string): string {
+    const dt = new Date(date + 'T00:00:00');
+    return dt.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  formatDateTime(date: string): string {
+    const dt = new Date(date);
+    if (isNaN(dt.getTime())) {
+      return date;
+    }
+    return dt.toLocaleString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
+  trackByDate(_: number, day: DayPlan): string {
+    return day.date;
+  }
+
+  recipeForMeal(day: DayPlan, type: MealType): Recipe | undefined {
+    const meal = day.meals[type];
+    return this.summary?.recipes.find((recipe) => recipe.id === meal.recipeId);
+  }
+}

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -1,0 +1,42 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import {
+  GenerateMealPlanRequest,
+  GroceryListSummary,
+  MealPlan,
+  MealPlanSummary,
+  Recipe
+} from '../types';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private readonly baseUrl = environment.apiUrl;
+
+  constructor(private readonly http: HttpClient) {}
+
+  getCurrentMealPlan(): Observable<MealPlan | null> {
+    return this.http.get<MealPlan | null>(`${this.baseUrl}/meal-plans/current`);
+  }
+
+  generateMealPlan(payload: GenerateMealPlanRequest): Observable<MealPlan> {
+    return this.http.post<MealPlan>(`${this.baseUrl}/meal-plans/generate`, payload);
+  }
+
+  getMealPlanSummary(): Observable<MealPlanSummary | null> {
+    return this.http.get<MealPlanSummary | null>(
+      `${this.baseUrl}/meal-plans/current/summary`
+    );
+  }
+
+  getGroceryList(): Observable<GroceryListSummary | null> {
+    return this.http.get<GroceryListSummary | null>(
+      `${this.baseUrl}/grocery-list/current`
+    );
+  }
+
+  getRecipes(): Observable<Recipe[]> {
+    return this.http.get<Recipe[]>(`${this.baseUrl}/recipes`);
+  }
+}

--- a/frontend/src/app/types.ts
+++ b/frontend/src/app/types.ts
@@ -1,0 +1,71 @@
+export type MealType = 'breakfast' | 'lunch' | 'dinner';
+
+export interface Ingredient {
+  id: number;
+  name: string;
+  unit: string;
+  pricePerUnit: number;
+  category: string;
+}
+
+export interface RecipeIngredient {
+  id: number;
+  ingredient: Ingredient;
+  quantity: number;
+  unit: string;
+}
+
+export interface Recipe {
+  id: number;
+  name: string;
+  description?: string;
+  mealType: MealType;
+  prepTimeMinutes: number;
+  servings: number;
+  ingredients: RecipeIngredient[];
+}
+
+export interface PlannedMeal {
+  recipeId: number;
+  recipeName: string;
+  mealType: MealType;
+}
+
+export interface DayPlan {
+  date: string;
+  meals: Record<MealType, PlannedMeal>;
+}
+
+export interface MealPlan {
+  id: number;
+  startDate: string;
+  endDate: string;
+  days: DayPlan[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface MealPlanSummary {
+  plan: MealPlan;
+  recipes: Recipe[];
+}
+
+export interface GroceryListItem {
+  ingredient: Ingredient;
+  totalQuantity: number;
+  unit: string;
+  estimatedCost: number;
+  substitution?: Ingredient | null;
+  potentialSavings?: number;
+}
+
+export interface GroceryListSummary {
+  items: GroceryListItem[];
+  totalCost: number;
+  potentialSavings: number;
+}
+
+export interface GenerateMealPlanRequest {
+  startDate?: string;
+  highlightedRecipes?: string[];
+}

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: 'https://your-production-api.example.com'
+};

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:3000'
+};

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Smart Meal Planner & Grocery Saver</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <app-root>Loading...</app-root>
+  </body>
+</html>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,12 @@
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));

--- a/frontend/src/polyfills.ts
+++ b/frontend/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,20 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', 'Segoe UI', Roboto, Arial, sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  background-color: #f1f5f9;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/frontend/src/test.ts
+++ b/frontend/src/test.ts
@@ -1,0 +1,4 @@
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "types": []
+  },
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts", "src/**/*.ts"],
+  "exclude": ["src/test.ts", "src/**/*.spec.ts"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2021", "dom"]
+  }
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/spec",
+    "types": ["jasmine"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- track meal plan creation timestamps and order current-plan lookups by newest entry so backdated generations still surface immediately
- surface the generated-at timestamp in the Angular dashboard and client types so users can see when the current plan was produced
- add ESLint configurations (flat + legacy) for both backend and frontend projects and wire up missing TypeScript ESLint dev dependencies for reliable linting

## Testing
- npm --prefix backend run lint *(fails: dependencies not installed in the execution environment)*
- npm --prefix frontend run lint *(fails: dependencies not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4586160e48327b1abe5cbbd5956ad